### PR TITLE
Ender chest modifications

### DIFF
--- a/src/main/java/mlh/goofygoofies/minecraft_rp/EnderChestListener.java
+++ b/src/main/java/mlh/goofygoofies/minecraft_rp/EnderChestListener.java
@@ -1,0 +1,73 @@
+package mlh.goofygoofies.minecraft_rp;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+
+public class EnderChestListener implements Listener {
+    /**
+     * Disallows placing items in an ender chest that aren't gold nuggets/ingots/blocks. Removing non-gold items from an ender chest is still allowed.
+     * @param event Event when the player clicks inside an inventory view
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onInventoryClick(InventoryClickEvent event) {
+        InventoryType inventory = event.getClickedInventory().getType();
+        InventoryAction action = event.getAction();
+        
+        if ((// Quick inventory swap (shift + click)
+                inventory == InventoryType.PLAYER &&
+                action == InventoryAction.MOVE_TO_OTHER_INVENTORY &&
+                // event.getWhoClicked().getOpenInventory().getTopInventory().getType() == InventoryType.ENDER_CHEST
+                event.getInventory().getType() == InventoryType.ENDER_CHEST
+            )||
+            (// Dropping an item into the ender chest
+                inventory == InventoryType.ENDER_CHEST &&
+                isDeposit(action)
+            )) {
+            if (!isCurrency(event.getCursor())) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    /**
+     * Disallows placing items in an ender chest that aren't gold nuggets/ingots/blocks via stack splitting (click and drag).
+     * @param event Event when the player drags inside an inventory view
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (event.getInventory().getType() == InventoryType.ENDER_CHEST && !isCurrency(event.getOldCursor())) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Whether an item stack contains valid currency
+     * @param stack Stack to analyze
+     * @return True if valid currency, false otherwise
+     */
+    boolean isCurrency(ItemStack stack) {
+        Material type = stack.getType();
+        return (type == Material.GOLD_BLOCK ||
+                type == Material.GOLD_INGOT ||
+                type == Material.GOLD_NUGGET);
+    }
+
+    /**
+     * Whether an InventoryAction is the player depositing items into the top inventory
+     * @param action InventoryAction taken by the player
+     * @return True if a depositing action, false otherwise
+     */
+    boolean isDeposit(InventoryAction action) {
+        return (action == InventoryAction.HOTBAR_SWAP ||
+                action == InventoryAction.PLACE_ALL ||
+                action == InventoryAction.PLACE_ONE ||
+                action == InventoryAction.PLACE_SOME ||
+                action == InventoryAction.SWAP_WITH_CURSOR);
+    }
+}

--- a/src/main/java/mlh/goofygoofies/minecraft_rp/EnderChestManager.java
+++ b/src/main/java/mlh/goofygoofies/minecraft_rp/EnderChestManager.java
@@ -1,5 +1,8 @@
 package mlh.goofygoofies.minecraft_rp;
 
+import java.util.Iterator;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,8 +11,24 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
 
-public class EnderChestListener implements Listener {
+public class EnderChestManager implements Listener {
+    /**
+     * Disallows crafting ender chests upon construction.
+     * As an event listener, this class disallows placing items in an ender chest that aren't gold nuggets/ingots/blocks.
+     */
+    public EnderChestManager() {
+        Iterator<Recipe> it = Bukkit.recipeIterator();
+        Recipe recipe;
+        while (it.hasNext()) {
+            recipe = it.next();
+            if (recipe.getResult().getType() == Material.ENDER_CHEST) {
+                it.remove();
+            }
+        }
+    }
+
     /**
      * Disallows placing items in an ender chest that aren't gold nuggets/ingots/blocks. Removing non-gold items from an ender chest is still allowed.
      * @param event Event when the player clicks inside an inventory view

--- a/src/main/java/mlh/goofygoofies/minecraft_rp/MinecraftRP.java
+++ b/src/main/java/mlh/goofygoofies/minecraft_rp/MinecraftRP.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.entity.Player;
 
@@ -44,7 +45,10 @@ public class MinecraftRP extends JavaPlugin implements Listener {
         getCommand("selfheal").setExecutor(lc);
         getCommand("unclaim").setExecutor(lc);
         
-        getServer().getPluginManager().registerEvents(this, this);
+        // Events
+        PluginManager pm = getServer().getPluginManager();
+        pm.registerEvents(new EnderChestListener(), this);
+        pm.registerEvents(this, this);
         getLogger().info("MinecraftRP plugin enabled.");
     }
 

--- a/src/main/java/mlh/goofygoofies/minecraft_rp/MinecraftRP.java
+++ b/src/main/java/mlh/goofygoofies/minecraft_rp/MinecraftRP.java
@@ -47,7 +47,7 @@ public class MinecraftRP extends JavaPlugin implements Listener {
         
         // Events
         PluginManager pm = getServer().getPluginManager();
-        pm.registerEvents(new EnderChestListener(), this);
+        pm.registerEvents(new EnderChestManager(), this);
         pm.registerEvents(this, this);
         getLogger().info("MinecraftRP plugin enabled.");
     }


### PR DESCRIPTION
Closes #8

Disables crafting ender chests and restricts ender chest storage to gold only. Please get sneaky and try everything you can think of if you want to test this!